### PR TITLE
Don't expose Hemmelig URL to Github

### DIFF
--- a/src/client/app-shell.jsx
+++ b/src/client/app-shell.jsx
@@ -67,6 +67,7 @@ const ApplicationShell = () => {
                             </>
                         )}
                         <Anchor
+                            rel="noreferrer"
                             href="https://github.com/HemmeligOrg/Hemmelig.app"
                             color="dimmed"
                             size="xs"


### PR DESCRIPTION
This PR prevents browsers from sending Hemmelig's URL to Github via the HTTP Referrer header.

More information: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noreferrer